### PR TITLE
Run the unit tests with FLASK_DEBUG=0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Please make sure:
 To view the templates in your browser, you can run a local flask server. To see your changes, refresh the page.
 ```
  export FLASK_APP=web flask run
- export FLASK_DEBUG=1
+ export FLASK_DEBUG=0
  python -m flask run
 ```
 Then you can view it on `http://127.0.0.1:5000/`


### PR DESCRIPTION
Running the unit testing suite with the environment variable FLASK_DEBUG=1 will cause the unit tests to fail intest_db.py, use FLASK_DEBUG=0 instead

Closes #100 