### PR TITLE
added stride param for avg_css_per_period

### DIFF
--- a/biz/css/manage_satisfaction.py
+++ b/biz/css/manage_satisfaction.py
@@ -51,8 +51,8 @@ def avg_css_per_period(db_conn, datetime_start, datetime_end, stride):
     :param db_conn: A psycopg2 connection to the database.
     :param datetime_start: The starting datetime for the time period.
     :param datetime_end: The ending datetime for the time period.
-    :param stride: The sub time period to split the
-        averages (hour, week, month).
+    :param stride: The sub time period to split the averages
+        ('hour', 'day', 'week', 'month', 'year').
     :return: Average CSS score for the time period.
     """
     with db_conn.cursor() as curs:

--- a/test/biz/test_manage_satisfaction.py
+++ b/test/biz/test_manage_satisfaction.py
@@ -104,7 +104,7 @@ def test_create_multiple_satisfaction(database_snapshot):
 
 def test_avg_css_per_period(database_snapshot):
     """Retrieve average css on and between
-    2018-01-01 11:00:00 and 2018-12-31 13:30:00
+    2018-01-01 11:00:00 and 2018-12-31 12:00:00
     """
     with database_snapshot.getconn() as conn:
         t, staff = h.spoof_tables(conn, 2)
@@ -140,7 +140,7 @@ def test_avg_css_per_period(database_snapshot):
 
 
 def test_missing_avg_css_per_period(database_snapshot):
-    """Retrieve missing average css on 2018-12-31"""
+    """Retrieve missing average css on 2018-01-01 11:00:00"""
     with database_snapshot.getconn() as conn:
         t, staff = h.spoof_tables(conn, 1)
         conn.commit()


### PR DESCRIPTION
Splitting the average CSS per specified period using the stride param.

Working stride params:
- [x] Hour
- [x] Day
- [x] Week
- [x] Month
- [x] Year